### PR TITLE
[Feat] #27 - CustomTextEditor 구현

### DIFF
--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Component/TextField/CustomTextEditor.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Component/TextField/CustomTextEditor.swift
@@ -1,0 +1,62 @@
+//
+//  CustomTextEditor.swift
+//  Gongbaek_iOS
+//
+//  Created by 김민서 on 1/15/25.
+//
+
+import SwiftUI
+
+struct CustomTextEditor: View {
+    @State var text = ""
+    @FocusState var isEditing: Bool
+    let maxCharacterCount = 100
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("소개글")
+                .font(.pretendard(.body2_sb_14))
+                .foregroundColor(.gray08)
+
+            ZStack(alignment: .topLeading) {
+                if text.isEmpty {
+                    Text("간단한 소개글을 20자 이상 작성해보세요.\nex) 화석된 사람들끼리 소소한 점심 모임 어때요?")
+                        .foregroundColor(.gray04)
+                        .padding(EdgeInsets(top: 14, leading: 16, bottom: 14, trailing: 16))
+                }
+
+                TextEditor(text: $text)
+                    .padding(EdgeInsets(top: 7, leading: 10, bottom: 0, trailing: 4))
+                    .scrollContentBackground(.hidden)
+                    .background(Color.clear)
+                    .onChange(of: text) { newValue in
+                        if newValue.count > maxCharacterCount {
+                            text = String(newValue.prefix(maxCharacterCount))
+                        }
+                    }
+                    .focused($isEditing)
+            }
+            .font(.pretendard(.body1_m_16))
+            .background(.gray01)
+            .accentColor(.gray05)
+            .frame(height: 143)
+            .cornerRadius(6)
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(isEditing ? .gray10 : Color.clear, lineWidth: 1)
+            )
+
+            HStack {
+                Spacer()
+                Text("\(text.count)/\(maxCharacterCount)")
+                    .font(.pretendard(.caption2_r_12))
+                    .foregroundColor(.gray06)
+            }
+        }
+    }
+}
+
+#Preview {
+    CustomTextEditor()
+        .padding(16)
+}

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Component/TextField/CustomTextEditor.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Component/TextField/CustomTextEditor.swift
@@ -29,9 +29,9 @@ struct CustomTextEditor: View {
                     .padding(EdgeInsets(top: 7, leading: 10, bottom: 0, trailing: 4))
                     .scrollContentBackground(.hidden)
                     .background(Color.clear)
-                    .onChange(of: text) { newValue in
-                        if newValue.count > maxCharacterCount {
-                            text = String(newValue.prefix(maxCharacterCount))
+                    .onChange(of: text) { [text] in
+                        if text.count > maxCharacterCount {
+                            self.text = String(text.prefix(maxCharacterCount))
                         }
                     }
                     .focused($isEditing)


### PR DESCRIPTION
## 🧩 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
CustomTextEditor 컴포넌트 구현했습니다!

## 🪁 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
## 1️⃣ TextEditor placeholer
SwiftUI의 TextEditor의 경우 placeholder역할을 하는 기능이 내장되어있지 않아요ㅠㅠ
그래서 꼭 커스텀해야하는데
```
if text.isEmpty { 
    Text("응애 나 placeholder")
        .font(.system(size: 16, weight: .medium))
        .foregroundColor(.gray)
        .padding(8)
}
```
 ZStack으로 placeholder text를 얹고 텍스트가 비어있다면
항상 placeholder가 뜨도록 구현하면 되긴하는데..!

문제는 TextEditor에 기본적으로 inset이 잡혀있는지... 
일반 Text와 padding 값이 다르게 보이는 이슈 !!
![Simulator Screen Recording - iPhone 16 - 2025-01-09 at 19 01 48](https://github.com/user-attachments/assets/76d292e9-6ba3-4075-b312-4242c8ad45a6)

그래서 placeholder를 기준으로
`.padding(EdgeInsets(top: 7, leading: 10, bottom: 0, trailing: 4))`
으로 위치를 잡아주긴 했습니다 ㅠㅠ 이게 최선인듯 ㅠㅠ

## 2️⃣ FocusState
그리고 입력하려고 탭하거나 입력중일 때는 이를 감지해 border를 주어야하는데
이걸 어떻게 감지하냐!
`@FocusState var isEditing: Bool`
SwiftUI에 FocusState라는 속성래퍼가 있습니다!

TextEditor에 FocusState로 선언해준 변수를 `focused()`로 걸어주고
그값이 true일 때만 overlay로 border를 지정해주었습니다!

이 속성 래퍼는 TextField나 TextEditor에서 키보드 내림 처리를 할 때도 자주 쓰이니
알아두면 자주 쓸 수 있을 것 같아요!



## 📱 스크린샷
<!-- 작업 내용, 스크린 샷(GIF/MP4) 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| CustomTextEditor | ![Simulator Screen Recording - iPhone 16 - 2025-01-15 at 16 04 59](https://github.com/user-attachments/assets/0f31231e-0e3b-49f8-b49a-3156e6d0509e)|



### 🔗 Issue 
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #27
